### PR TITLE
fix: remove redundant @MainActor from generated enum conformances (Swift 6)

### DIFF
--- a/Sources/ScaffoldingMacros/ScaffoldableMacro.swift
+++ b/Sources/ScaffoldingMacros/ScaffoldableMacro.swift
@@ -237,12 +237,12 @@ public struct ScaffoldableMacro: MemberMacro {
         
         let accessModifier = isPublic ? "public " : ""
         
-        let destinationsEnum = try EnumDeclSyntax("\(raw: accessModifier)enum Destinations: @MainActor Destinationable") {
+        let destinationsEnum = try EnumDeclSyntax("\(raw: accessModifier)enum Destinations: Destinationable") {
             // typealias Owner = ClassName
             DeclSyntax("\(raw: accessModifier)typealias Owner = \(raw: className)")
             
             // Meta enum
-            try EnumDeclSyntax("\(raw: accessModifier)enum Meta: @MainActor DestinationMeta") {
+            try EnumDeclSyntax("\(raw: accessModifier)enum Meta: DestinationMeta") {
                 for caseElement in metaCases {
                     EnumCaseDeclSyntax {
                         caseElement


### PR DESCRIPTION
## Summary

- Removes redundant `@MainActor` annotation from generated `Destinations: Destinationable` and `Meta: DestinationMeta` enum conformances in `ScaffoldableMacro.swift`

## Problem

In Swift 6's strict concurrency model, the `@MainActor` annotation on these generated enum conformances is redundant because both `Destinationable` and `DestinationMeta` protocols are already marked `@MainActor`. The compiler infers `@MainActor` isolation from the protocol conformance automatically.

With Swift 6 strict concurrency enabled, the redundant annotation triggers concurrency warnings/errors in consuming projects.

## Changes

**`Sources/ScaffoldingMacros/ScaffoldableMacro.swift`**:
```diff
- enum Destinations: @MainActor Destinationable
+ enum Destinations: Destinationable

- enum Meta: @MainActor DestinationMeta
+ enum Meta: DestinationMeta
```

## Test plan

- [x] Verified the fix resolves Swift 6 strict concurrency warnings in a consuming project (Goulash iOS app)
- [x] Build Scaffolding package tests