### PR TITLE
Fix missing setParent on root coordinatables in FlowStack and Root

### DIFF
--- a/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
+++ b/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
@@ -71,6 +71,7 @@ public class FlowStack<Coordinator: FlowCoordinatable>: AnyFlowStack {
             var rootDest = rootDestination.value(for: coordinator)
 
             rootDest.coordinatable?.setHasLayerNavigationCoordinatable(true)
+            rootDest.coordinatable?.setParent(coordinator)
 
             if let presentedAs = presentedAs {
                 rootDest.setPushType(presentedAs)
@@ -164,6 +165,7 @@ extension FlowStack {
          withAnimation(animation ?? self.animation) {
              var mutableRoot = root
              mutableRoot.coordinatable?.setHasLayerNavigationCoordinatable(true)
+             mutableRoot.coordinatable?.setParent(coordinator)
 
              if let presentedAs = presentedAs, mutableRoot.pushType == nil {
                  mutableRoot.setPushType(presentedAs)

--- a/Sources/Scaffolding/RootCoordinatable/Root.swift
+++ b/Sources/Scaffolding/RootCoordinatable/Root.swift
@@ -63,6 +63,7 @@ public class Root<Coordinator: RootCoordinatable>: AnyRoot {
                 var rootDest = rootDestination.value(for: coordinator)
 
                 rootDest.coordinatable?.setHasLayerNavigationCoordinatable(self.hasLayerNavigationCoordinator)
+                rootDest.coordinatable?.setParent(coordinator)
 
                 if let presentedAs = presentedAs {
                     rootDest.setPushType(presentedAs)


### PR DESCRIPTION
## Summary

- `FlowStack.setup()` and `Root.setup()` do not call `setParent()` on their root coordinatable, which breaks the parent chain for any coordinator that is the root destination of a `FlowStack` or `Root`
- This means `findAncestor(ofType:)` traversals stop early — deeply nested coordinators cannot reach their ancestors
- `TabItems.setup()` already calls `setParent(coordinator)` correctly (line 87); this PR aligns `FlowStack` and `Root` with that behavior

## Changes

- **FlowStack.swift**: Added `rootDest.coordinatable?.setParent(coordinator)` in `setup(for:)` and `setRoot(root:animation:)`
- **Root.swift**: Added `rootDest.coordinatable?.setParent(coordinator)` in `setup(for:)`

## How to reproduce

1. Create a coordinator hierarchy: `AppCoordinator → TabCoordinator → FlowCoordinator A → FlowCoordinator B → FlowCoordinator C`
2. FlowCoordinator B is the **root destination** of FlowCoordinator A's `FlowStack`
3. From FlowCoordinator C, call `findAncestor(ofType: AppCoordinator.self)`
4. The traversal stops at FlowCoordinator B because `B.parent` is `nil`

## Root cause

In `FlowStack.setup()`:
```swift
var rootDest = rootDestination.value(for: coordinator)
rootDest.coordinatable?.setHasLayerNavigationCoordinatable(true)
// ← setParent was missing here
root = rootDest
```

Compare with `TabItems.setup()` which works correctly:
```swift
var t = $0.value(for: coordinator)
t.coordinatable?.setHasLayerNavigationCoordinatable(...)
t.coordinatable?.setParent(coordinator)  // ✓
```

And `performRoute()` which also works correctly for pushed (non-root) destinations:
```swift
dest.coordinatable?.setParent(self)  // ✓
```