### PR TITLE
Fix unwrap of optional coordinator in FlowStack.setRoot

### DIFF
--- a/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
+++ b/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
@@ -165,6 +165,10 @@ extension FlowStack {
              var mutableRoot = root
              mutableRoot.coordinatable?.setHasLayerNavigationCoordinatable(true)
 
+             if let coordinator = coordinator {
+                 mutableRoot.coordinatable?.setParent(coordinator)
+             }
+
              if let presentedAs = presentedAs, mutableRoot.pushType == nil {
                  mutableRoot.setPushType(presentedAs)
              }


### PR DESCRIPTION
## Summary

- Fixes compile error introduced in 2.1.4 where `coordinator` (an optional `Coordinator?` property) was passed directly to `setParent` in `FlowStack.setRoot()` without unwrapping
- Wraps the call in `if let coordinator = coordinator { ... }` to match the library's existing style