### PR TITLE
Remove duplicate setParent call that fails to compile

### DIFF
--- a/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
+++ b/Sources/Scaffolding/FlowCoordinatable/FlowStack.swift
@@ -165,7 +165,6 @@ extension FlowStack {
          withAnimation(animation ?? self.animation) {
              var mutableRoot = root
              mutableRoot.coordinatable?.setHasLayerNavigationCoordinatable(true)
-             mutableRoot.coordinatable?.setParent(coordinator)
 
              if let coordinator = coordinator {
                  mutableRoot.coordinatable?.setParent(coordinator)


### PR DESCRIPTION
## Summary

- Removes the duplicate `mutableRoot.coordinatable?.setParent(coordinator)` on line 168 that was left over from PR #2
- This line passes the optional `coordinator` without unwrapping, causing a compile error
- The correct `if let` version from PR #3 already exists directly below it